### PR TITLE
Fix down migration to drop products table

### DIFF
--- a/migrations/2025-07-29-041101_create-products/down.sql
+++ b/migrations/2025-07-29-041101_create-products/down.sql
@@ -1,2 +1,3 @@
 -- This file should undo anything in `up.sql`
+DROP TABLE products;
 DROP TABLE benchmarks;


### PR DESCRIPTION
## Summary
- fix `migrations/2025-07-29-041101_create-products/down.sql` so the products table is dropped as well

## Testing
- `cargo test` *(fails: network access blocked to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6889299942d8832fbf9b9d0adcff57db