### PR TITLE
Fix variable typo

### DIFF
--- a/crawlers/pushkind_crawlers/crawler/stores/tea101.py
+++ b/crawlers/pushkind_crawlers/crawler/stores/tea101.py
@@ -109,7 +109,7 @@ async def parse_101tea() -> list[Product]:
     categories = await parser_101.get_categories()
     for category in categories:
         log.info("Processing category: %s", category.name)
-        categery_products = []
+        category_products = []
         try:
             pages = await parser_101.get_pages(category.url)
         except Exception:
@@ -120,8 +120,8 @@ async def parse_101tea() -> list[Product]:
                 page_products = await parser_101.get_products(page)
             except Exception:
                 continue
-            categery_products += page_products
-        all_products += categery_products
+            category_products += page_products
+        all_products += category_products
 
     # remove duplicate products based on product.url
     unique_products = {p.url: p for p in all_products}.values()


### PR DESCRIPTION
## Summary
- fix a typo in `tea101.py` by renaming `categery_products` to `category_products`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_688929b38134832f946edda168fd5b57