### PR TITLE
Show product distances on benchmark page

### DIFF
--- a/src/domain/product.rs
+++ b/src/domain/product.rs
@@ -13,6 +13,10 @@ pub struct Product {
     pub amount: Option<f64>,
     pub description: Option<String>,
     pub url: String,
+    /// Similarity distance when associated with a benchmark
+    ///
+    /// This field is optional as most product listings don't include it.
+    pub distance: Option<f32>,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }

--- a/src/models/product.rs
+++ b/src/models/product.rs
@@ -33,6 +33,27 @@ impl From<Product> for DomainProduct {
             amount: product.amount,
             description: product.description,
             url: product.url,
+            distance: None,
+            created_at: product.created_at,
+            updated_at: product.updated_at,
+        }
+    }
+}
+
+impl From<(Product, f32)> for DomainProduct {
+    fn from((product, distance): (Product, f32)) -> Self {
+        Self {
+            id: product.id,
+            crawler_id: product.crawler_id,
+            name: product.name,
+            sku: product.sku,
+            category: product.category,
+            units: product.units,
+            price: product.price,
+            amount: product.amount,
+            description: product.description,
+            url: product.url,
+            distance: Some(distance),
             created_at: product.created_at,
             updated_at: product.updated_at,
         }

--- a/src/routes/benchmarks.rs
+++ b/src/routes/benchmarks.rs
@@ -15,8 +15,8 @@ use crate::domain::benchmark::NewBenchmark;
 use crate::forms::benchmarks::{AddBenchmarkForm, UploadBenchmarksForm};
 use crate::repository::benchmark::DieselBenchmarkRepository;
 use crate::repository::product::DieselProductRepository;
-use crate::repository::{BenchmarkListQuery, ProductListQuery};
-use crate::repository::{BenchmarkReader, BenchmarkWriter, ProductReader};
+use crate::repository::BenchmarkListQuery;
+use crate::repository::{BenchmarkReader, BenchmarkWriter};
 use crate::routes::render_template;
 
 #[derive(Deserialize)]
@@ -111,13 +111,15 @@ pub async fn show_benchmark(
 
     let product_repo = DieselProductRepository::new(&pool);
 
-    let products = match product_repo.list(ProductListQuery::default().benchmark(benchmark_id)) {
-        Ok((_total, products)) => products,
+    let products = match product_repo.list_for_benchmark_with_distance(benchmark_id) {
+        Ok(products) => products,
         Err(e) => {
             log::error!("Failed to list products: {e}");
             return HttpResponse::InternalServerError().finish();
         }
     };
+
+    context.insert("show_distance", &true);
 
     context.insert("benchmark", &benchmark);
     context.insert("products", &products);

--- a/templates/benchmarks/benchmark.html
+++ b/templates/benchmarks/benchmark.html
@@ -3,6 +3,8 @@
 {% block content %}
     {% include 'components/navigation.html' %}
 
+    {% set show_distance = false %}
+
     <div class="container bg-white border rounded my-2">
         <h5>Бенчмарк</h5>
         {% include 'components/product_header.html' %}
@@ -13,6 +15,7 @@
     </div>
 
 
+    {% set show_distance = true %}
     <div class="container bg-white border rounded my-2">
         <h5>Товары</h5>
         {% include 'components/product_header.html' %}

--- a/templates/components/product.html
+++ b/templates/components/product.html
@@ -1,4 +1,9 @@
 <div class="row my-1 py-1 border-top product {%if product_kind%}selectable{%endif%}" data-id={{product.id}} data-kind="{{product_kind | default(value="") }}">
+    {% if show_distance is defined and show_distance %}
+    <div class="col overflow-hidden">
+        {{ product.distance | default(value="") }}
+    </div>
+    {% endif %}
     <div class="col overflow-hidden">
         {{product.name}}
     </div>

--- a/templates/components/product_header.html
+++ b/templates/components/product_header.html
@@ -1,4 +1,9 @@
 <div class="row d-none d-sm-flex fw-bold">
+    {% if show_distance is defined and show_distance %}
+    <div class="col overflow-hidden">
+        Расстояние
+    </div>
+    {% endif %}
     <div class="col overflow-hidden">
         Название
     </div>


### PR DESCRIPTION
## Summary
- keep track of product benchmark distance in domain model
- expose distance when selecting products for a benchmark
- sort benchmark products by distance
- render optional distance column on benchmark pages

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688a2d8bf540832f80b0850b10b75cf4