### PR TITLE
docs: add missing comments and cleanup

### DIFF
--- a/src/forms/benchmarks.rs
+++ b/src/forms/benchmarks.rs
@@ -2,13 +2,13 @@ use std::io::Read;
 
 use actix_multipart::form::{MultipartForm, tempfile::TempFile};
 use chrono::Utc;
-use csv;
 use serde::Deserialize;
 use thiserror::Error;
 use validator::Validate;
 
 use pushkind_common::domain::benchmark::NewBenchmark;
 
+/// Form data for creating a single benchmark item via the UI.
 #[derive(Deserialize, Validate)]
 pub struct AddBenchmarkForm {
     #[validate(length(min = 1))]
@@ -26,6 +26,7 @@ pub struct AddBenchmarkForm {
 }
 
 impl AddBenchmarkForm {
+    /// Convert the validated form into a [`NewBenchmark`] domain model.
     pub fn into_new_benchmark(self, hub_id: i32) -> NewBenchmark {
         let now = Utc::now().naive_utc();
         NewBenchmark {
@@ -43,16 +44,21 @@ impl AddBenchmarkForm {
     }
 }
 
+/// Multipart form for uploading a CSV file with multiple benchmarks.
 #[derive(MultipartForm)]
 pub struct UploadBenchmarksForm {
+    /// Uploaded CSV file containing benchmark rows.
     #[multipart(limit = "10MB")]
     pub csv: TempFile,
 }
 
+/// Errors that can occur while processing a [`UploadBenchmarksForm`].
 #[derive(Debug, Error)]
 pub enum UploadBenchmarksFormError {
+    /// Wrapper for I/O errors when reading the uploaded file.
     #[error("Error reading csv file")]
     FileReadError,
+    /// The CSV content could not be parsed into benchmark records.
     #[error("Error parsing csv file")]
     CsvParseError,
 }
@@ -81,6 +87,7 @@ struct CsvBenchmarkRow {
 }
 
 impl UploadBenchmarksForm {
+    /// Parse the uploaded CSV file into a list of [`NewBenchmark`] records.
     pub fn parse(&mut self, hub_id: i32) -> Result<Vec<NewBenchmark>, UploadBenchmarksFormError> {
         let mut csv_content = String::new();
         self.csv.file.read_to_string(&mut csv_content)?;
@@ -110,14 +117,20 @@ impl UploadBenchmarksForm {
     }
 }
 
+/// Form used to remove a benchmark association from a product.
 #[derive(Deserialize)]
 pub struct UnassociateForm {
+    /// Benchmark identifier.
     pub benchmark_id: i32,
+    /// Product identifier.
     pub product_id: i32,
 }
 
+/// Form used to create a benchmark association for a product.
 #[derive(Deserialize)]
 pub struct AssociateForm {
+    /// Benchmark identifier.
     pub benchmark_id: i32,
+    /// Product identifier.
     pub product_id: i32,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+//! Core library exports for the Dantes service.
+//!
+//! This crate exposes forms, models, repositories, routes and service layers
+//! used by the Dantes web application.
+
 pub mod forms;
 pub mod models;
 pub mod repository;

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -1,4 +1,6 @@
+/// Configuration options specific to the Dantes service.
 #[derive(Clone)]
 pub struct ServerConfig {
+    /// Address of the ZeroMQ socket used for communication with workers.
     pub zmq_address: String,
 }

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -11,33 +11,48 @@ pub mod benchmark;
 pub mod crawler;
 pub mod product;
 
+/// Repository implementation backed by Diesel and SQLite.
+///
+/// The underlying `r2d2::Pool` is cheap to clone, allowing the repository to
+/// be passed around freely between handlers.
 #[derive(Clone)]
 pub struct DieselRepository {
     pool: DbPool, // r2d2::Pool is cheap to clone
 }
 
 impl DieselRepository {
+    /// Create a new repository from an established database pool.
     pub fn new(pool: DbPool) -> Self {
         Self { pool }
     }
 
+    /// Get a pooled database connection.
     fn conn(&self) -> RepositoryResult<DbConnection> {
         Ok(self.pool.get()?)
     }
 }
 
+/// Query parameters used when listing or searching products.
 #[derive(Debug, Clone, Default)]
 pub struct ProductListQuery {
+    /// Filter by crawler identifier.
     pub crawler_id: Option<i32>,
+    /// Filter by hub identifier.
     pub hub_id: Option<i32>,
+    /// Restrict to products associated with a benchmark.
     pub benchmark_id: Option<i32>,
+    /// Full-text search string.
     pub search: Option<String>,
+    /// Pagination parameters.
     pub pagination: Option<Pagination>,
 }
 
+/// Query parameters for listing benchmarks belonging to a hub.
 #[derive(Debug, Clone)]
 pub struct BenchmarkListQuery {
+    /// Hub identifier.
     pub hub_id: i32,
+    /// Pagination parameters.
     pub pagination: Option<Pagination>,
 }
 
@@ -77,37 +92,52 @@ impl ProductListQuery {
     }
 }
 
+/// Read-only operations for crawler entities.
 pub trait CrawlerReader {
+    /// List all crawlers for a specific hub.
     fn list_crawlers(&self, hub_id: i32) -> RepositoryResult<Vec<Crawler>>;
+    /// Retrieve a crawler by its identifier.
     fn get_crawler_by_id(&self, id: i32) -> RepositoryResult<Option<Crawler>>;
 }
 
 pub trait CrawlerWriter {}
 
+/// Read-only operations for product entities.
 pub trait ProductReader {
+    /// List products matching the supplied query parameters.
     fn list_products(&self, query: ProductListQuery) -> RepositoryResult<(usize, Vec<Product>)>;
+    /// Return a mapping of product identifiers to similarity distances for a benchmark.
     fn list_distances(&self, benchmark_id: i32) -> RepositoryResult<HashMap<i32, f32>>;
+    /// Perform a full-text search for products.
     fn search_products(&self, query: ProductListQuery) -> RepositoryResult<(usize, Vec<Product>)>;
+    /// Retrieve a product by its identifier.
     fn get_product_by_id(&self, id: i32) -> RepositoryResult<Option<Product>>;
 }
 
 pub trait ProductWriter {}
 
+/// Read-only operations for benchmark entities.
 pub trait BenchmarkReader {
+    /// List benchmarks using the supplied query options.
     fn list_benchmarks(
         &self,
         query: BenchmarkListQuery,
     ) -> RepositoryResult<(usize, Vec<Benchmark>)>;
+    /// Retrieve a benchmark by its identifier.
     fn get_benchmark_by_id(&self, id: i32) -> RepositoryResult<Option<Benchmark>>;
 }
 
+/// Write operations for benchmark entities and their associations.
 pub trait BenchmarkWriter {
+    /// Persist new benchmark records.
     fn create_benchmark(&self, benchmarks: &[NewBenchmark]) -> RepositoryResult<usize>;
+    /// Remove an association between a benchmark and a product.
     fn remove_benchmark_association(
         &self,
         benchmark_id: i32,
         product_id: i32,
     ) -> RepositoryResult<usize>;
+    /// Create or update an association between a benchmark and a product with a similarity distance.
     fn set_benchmark_association(
         &self,
         benchmark_id: i32,

--- a/src/repository/product.rs
+++ b/src/repository/product.rs
@@ -8,6 +8,7 @@ use pushkind_common::repository::errors::RepositoryResult;
 
 use crate::repository::{DieselRepository, ProductListQuery, ProductReader, ProductWriter};
 
+/// Helper struct used to capture the result of a `COUNT(*)` query.
 #[derive(QueryableByName)]
 struct ProductCount {
     #[diesel(sql_type = diesel::sql_types::BigInt)]


### PR DESCRIPTION
## Summary
- document benchmark form structures and errors
- add doc comments for repository queries and traits
- clarify server configuration options

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689b424e29b0832abb97c0c73bccd3ca