### PR TITLE
Refactor product API into service layer

### DIFF
--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -10,6 +10,8 @@ use pushkind_common::repository::errors::RepositoryResult;
 pub mod benchmark;
 pub mod crawler;
 pub mod product;
+#[cfg(test)]
+pub mod test;
 
 /// Repository implementation backed by Diesel and SQLite.
 ///

--- a/src/repository/test.rs
+++ b/src/repository/test.rs
@@ -1,0 +1,107 @@
+use std::collections::HashMap;
+
+use pushkind_common::domain::{crawler::Crawler, product::Product};
+use pushkind_common::repository::errors::RepositoryResult;
+
+use crate::repository::{CrawlerReader, ProductListQuery, ProductReader};
+
+/// Simple in-memory repository used for unit tests.
+#[derive(Default)]
+pub struct TestRepository {
+    crawlers: HashMap<i32, Crawler>,
+    products: Vec<Product>,
+}
+
+impl TestRepository {
+    pub fn new(crawlers: Vec<Crawler>, products: Vec<Product>) -> Self {
+        Self {
+            crawlers: crawlers.into_iter().map(|c| (c.id, c)).collect(),
+            products,
+        }
+    }
+
+    fn clone_crawler(c: &Crawler) -> Crawler {
+        Crawler {
+            id: c.id,
+            hub_id: c.hub_id,
+            name: c.name.clone(),
+            url: c.url.clone(),
+            selector: c.selector.clone(),
+            processing: c.processing,
+            updated_at: c.updated_at,
+            num_products: c.num_products,
+        }
+    }
+
+    fn clone_product(p: &Product) -> Product {
+        Product {
+            id: p.id,
+            crawler_id: p.crawler_id,
+            name: p.name.clone(),
+            sku: p.sku.clone(),
+            category: p.category.clone(),
+            units: p.units.clone(),
+            price: p.price,
+            amount: p.amount,
+            description: p.description.clone(),
+            url: p.url.clone(),
+            created_at: p.created_at,
+            updated_at: p.updated_at,
+            embedding: p.embedding.clone(),
+        }
+    }
+}
+
+impl CrawlerReader for TestRepository {
+    fn list_crawlers(&self, hub_id: i32) -> RepositoryResult<Vec<Crawler>> {
+        Ok(
+            self
+                .crawlers
+                .values()
+                .filter(|c| c.hub_id == hub_id)
+                .map(Self::clone_crawler)
+                .collect(),
+        )
+    }
+
+    fn get_crawler_by_id(&self, id: i32) -> RepositoryResult<Option<Crawler>> {
+        Ok(self.crawlers.get(&id).map(Self::clone_crawler))
+    }
+}
+
+impl ProductReader for TestRepository {
+    fn list_products(&self, query: ProductListQuery) -> RepositoryResult<(usize, Vec<Product>)> {
+        let mut items: Vec<Product> = self.products.iter().map(Self::clone_product).collect();
+        if let Some(crawler_id) = query.crawler_id {
+            items.retain(|p| p.crawler_id == crawler_id);
+        }
+        let total = items.len();
+        Ok((total, items))
+    }
+
+    fn list_distances(&self, _benchmark_id: i32) -> RepositoryResult<HashMap<i32, f32>> {
+        Ok(HashMap::new())
+    }
+
+    fn search_products(&self, query: ProductListQuery) -> RepositoryResult<(usize, Vec<Product>)> {
+        let mut items: Vec<Product> = self.products.iter().map(Self::clone_product).collect();
+        if let Some(crawler_id) = query.crawler_id {
+            items.retain(|p| p.crawler_id == crawler_id);
+        }
+        if let Some(search) = query.search {
+            let search = search.to_lowercase();
+            items.retain(|p| p.name.to_lowercase().contains(&search));
+        }
+        let total = items.len();
+        Ok((total, items))
+    }
+
+    fn get_product_by_id(&self, id: i32) -> RepositoryResult<Option<Product>> {
+        Ok(self
+            .products
+            .iter()
+            .find(|p| p.id == id)
+            .map(Self::clone_product))
+    }
+}
+

--- a/src/routes/api.rs
+++ b/src/routes/api.rs
@@ -1,19 +1,9 @@
 use actix_web::{HttpResponse, Responder, get, web};
-use log::error;
-use pushkind_common::domain::product::Product;
 use pushkind_common::models::auth::AuthenticatedUser;
-use pushkind_common::pagination::DEFAULT_ITEMS_PER_PAGE;
-use pushkind_common::routes::ensure_role;
-use serde::Deserialize;
 
-use crate::repository::{CrawlerReader, DieselRepository, ProductListQuery, ProductReader};
-
-#[derive(Deserialize, Debug)]
-struct ApiV1ProductsQueryParams {
-    crawler_id: i32,
-    query: Option<String>,
-    page: Option<usize>,
-}
+use crate::repository::DieselRepository;
+use crate::services::api::{api_v1_products as api_v1_products_service, ApiV1ProductsQueryParams};
+use crate::services::errors::ServiceError;
 
 #[get("/v1/products")]
 pub async fn api_v1_products(
@@ -21,46 +11,10 @@ pub async fn api_v1_products(
     user: AuthenticatedUser,
     repo: web::Data<DieselRepository>,
 ) -> impl Responder {
-    if ensure_role(&user, "parser", None).is_err() {
-        return HttpResponse::Unauthorized().finish();
-    }
-
-    let crawler = match repo.get_crawler_by_id(params.crawler_id) {
-        Ok(Some(crawler)) if crawler.hub_id == user.hub_id => crawler,
-        Err(e) => {
-            error!("Failed to get crawler: {e}");
-            return HttpResponse::InternalServerError().finish();
-        }
-        _ => return HttpResponse::NotFound().finish(),
-    };
-
-    let mut list_query = ProductListQuery::default().crawler(crawler.id);
-
-    let page = params.page.unwrap_or(1);
-
-    list_query = list_query.paginate(page, DEFAULT_ITEMS_PER_PAGE);
-
-    let result = match &params.query {
-        Some(query) if !query.is_empty() => {
-            list_query = list_query.search(query);
-            repo.search_products(list_query)
-        }
-        _ => repo.list_products(list_query),
-    };
-
-    match result {
-        Ok((_total, products)) => HttpResponse::Ok().json(
-            products
-                .into_iter()
-                .map(|mut p| {
-                    p.embedding = None;
-                    p
-                })
-                .collect::<Vec<Product>>(),
-        ),
-        Err(e) => {
-            error!("Failed to list products: {e}");
-            HttpResponse::InternalServerError().finish()
-        }
+    match api_v1_products_service(repo.get_ref(), params.into_inner(), &user) {
+        Ok(products) => HttpResponse::Ok().json(products),
+        Err(ServiceError::Unauthorized) => HttpResponse::Unauthorized().finish(),
+        Err(ServiceError::NotFound) => HttpResponse::NotFound().finish(),
+        Err(ServiceError::Internal) => HttpResponse::InternalServerError().finish(),
     }
 }

--- a/src/services/api.rs
+++ b/src/services/api.rs
@@ -1,1 +1,142 @@
+use log::error;
+use pushkind_common::domain::product::Product;
+use pushkind_common::models::auth::AuthenticatedUser;
+use pushkind_common::pagination::DEFAULT_ITEMS_PER_PAGE;
+use pushkind_common::routes::ensure_role;
+use serde::Deserialize;
+
+use crate::repository::{CrawlerReader, ProductListQuery, ProductReader};
+
+use super::errors::{ServiceError, ServiceResult};
+
+/// Query parameters accepted by the `api_v1_products` endpoint.
+#[derive(Deserialize, Debug)]
+pub struct ApiV1ProductsQueryParams {
+    pub crawler_id: i32,
+    pub query: Option<String>,
+    pub page: Option<usize>,
+}
+
+/// Core business logic for the `/v1/products` API endpoint.
+///
+/// The function returns a list of products for the requested crawler,
+/// performing optional search and pagination. All repository interactions and
+/// role checks are handled here so that the HTTP route can remain a thin
+/// wrapper.
+pub fn api_v1_products<R>(
+    repo: &R,
+    params: ApiV1ProductsQueryParams,
+    user: &AuthenticatedUser,
+) -> ServiceResult<Vec<Product>>
+where
+    R: CrawlerReader + ProductReader,
+{
+    if ensure_role(user, "parser", None).is_err() {
+        return Err(ServiceError::Unauthorized);
+    }
+
+    let crawler = match repo.get_crawler_by_id(params.crawler_id) {
+        Ok(Some(crawler)) if crawler.hub_id == user.hub_id => crawler,
+        Err(e) => {
+            error!("Failed to get crawler: {e}");
+            return Err(ServiceError::Internal);
+        }
+        _ => return Err(ServiceError::NotFound),
+    };
+
+    let mut list_query = ProductListQuery::default().crawler(crawler.id);
+
+    let page = params.page.unwrap_or(1);
+    list_query = list_query.paginate(page, DEFAULT_ITEMS_PER_PAGE);
+
+    let result = match &params.query {
+        Some(query) if !query.is_empty() => {
+            list_query = list_query.search(query);
+            repo.search_products(list_query)
+        }
+        _ => repo.list_products(list_query),
+    };
+
+    match result {
+        Ok((_total, products)) => Ok(
+            products
+                .into_iter()
+                .map(|mut p| {
+                    p.embedding = None;
+                    p
+                })
+                .collect::<Vec<Product>>(),
+        ),
+        Err(e) => {
+            error!("Failed to list products: {e}");
+            Err(ServiceError::Internal)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repository::test::TestRepository;
+    use chrono::NaiveDateTime;
+    use pushkind_common::domain::{crawler::Crawler, product::Product};
+
+    fn sample_user() -> AuthenticatedUser {
+        AuthenticatedUser {
+            sub: "1".into(),
+            email: "test@example.com".into(),
+            hub_id: 1,
+            name: "Test".into(),
+            roles: vec!["parser".into()],
+            exp: 0,
+        }
+    }
+
+    fn sample_crawler() -> Crawler {
+        Crawler {
+            id: 1,
+            hub_id: 1,
+            name: "crawler".into(),
+            url: "http://example.com".into(),
+            selector: "body".into(),
+            processing: false,
+            updated_at: NaiveDateTime::from_timestamp(0, 0),
+            num_products: 0,
+        }
+    }
+
+    fn sample_product() -> Product {
+        Product {
+            id: 1,
+            crawler_id: 1,
+            name: "Apple".into(),
+            sku: "SKU1".into(),
+            category: None,
+            units: None,
+            price: 1.0,
+            amount: None,
+            description: None,
+            url: "http://example.com/apple".into(),
+            created_at: NaiveDateTime::from_timestamp(0, 0),
+            updated_at: NaiveDateTime::from_timestamp(0, 0),
+            embedding: Some(vec![1, 2, 3]),
+        }
+    }
+
+    #[test]
+    fn returns_products_without_embeddings() {
+        let repo = TestRepository::new(vec![sample_crawler()], vec![sample_product()]);
+        let user = sample_user();
+        let params = ApiV1ProductsQueryParams {
+            crawler_id: 1,
+            query: None,
+            page: None,
+        };
+
+        let result = api_v1_products(&repo, params, &user).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].embedding.is_none());
+    }
+}
 

--- a/src/services/errors.rs
+++ b/src/services/errors.rs
@@ -1,1 +1,19 @@
+use thiserror::Error;
+
+/// Generic error type used by service layer functions.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ServiceError {
+    /// The user is not authorized to perform the operation.
+    #[error("unauthorized")]
+    Unauthorized,
+    /// Requested resource was not found.
+    #[error("not found")]
+    NotFound,
+    /// An unexpected internal error occurred.
+    #[error("internal error")]
+    Internal,
+}
+
+/// Convenient alias for results returned from service functions.
+pub type ServiceResult<T> = Result<T, ServiceError>;
 


### PR DESCRIPTION
## Summary
- Move product listing logic from route to `services::api::api_v1_products`
- Expose a thin HTTP wrapper and new `ServiceError` type
- Add in-memory `TestRepository` and unit test for service

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689b8f235e34832ab4c2a6c4fc1a1743