### PR TITLE
Refactor benchmarks route into service layer

### DIFF
--- a/src/services/api.rs
+++ b/src/services/api.rs
@@ -58,15 +58,13 @@ where
     };
 
     match result {
-        Ok((_total, products)) => Ok(
-            products
-                .into_iter()
-                .map(|mut p| {
-                    p.embedding = None;
-                    p
-                })
-                .collect::<Vec<Product>>(),
-        ),
+        Ok((_total, products)) => Ok(products
+            .into_iter()
+            .map(|mut p| {
+                p.embedding = None;
+                p
+            })
+            .collect::<Vec<Product>>()),
         Err(e) => {
             error!("Failed to list products: {e}");
             Err(ServiceError::Internal)
@@ -125,7 +123,7 @@ mod tests {
 
     #[test]
     fn returns_products_without_embeddings() {
-        let repo = TestRepository::new(vec![sample_crawler()], vec![sample_product()]);
+        let repo = TestRepository::new(vec![sample_crawler()], vec![sample_product()], vec![]);
         let user = sample_user();
         let params = ApiV1ProductsQueryParams {
             crawler_id: 1,
@@ -139,4 +137,3 @@ mod tests {
         assert!(result[0].embedding.is_none());
     }
 }
-

--- a/src/services/benchmarks.rs
+++ b/src/services/benchmarks.rs
@@ -1,1 +1,91 @@
+use log::error;
+use pushkind_common::domain::benchmark::Benchmark;
+use pushkind_common::models::auth::AuthenticatedUser;
+use pushkind_common::pagination::{DEFAULT_ITEMS_PER_PAGE, Paginated};
+use pushkind_common::routes::ensure_role;
 
+use crate::repository::{BenchmarkListQuery, BenchmarkReader};
+
+use super::errors::{ServiceError, ServiceResult};
+
+/// Core business logic for rendering the benchmarks page.
+///
+/// Validates the `parser` role and fetches paginated benchmarks for the
+/// user's hub. Repository errors are translated into [`ServiceError`] so the
+/// HTTP route can remain a thin wrapper.
+pub fn show_benchmarks<R>(
+    repo: &R,
+    user: &AuthenticatedUser,
+    page: usize,
+) -> ServiceResult<Paginated<Benchmark>>
+where
+    R: BenchmarkReader,
+{
+    if ensure_role(user, "parser", None).is_err() {
+        return Err(ServiceError::Unauthorized);
+    }
+
+    match repo.list_benchmarks(
+        BenchmarkListQuery::new(user.hub_id).paginate(page, DEFAULT_ITEMS_PER_PAGE),
+    ) {
+        Ok((total, benchmarks)) => Ok(Paginated::new(
+            benchmarks,
+            page,
+            total.div_ceil(DEFAULT_ITEMS_PER_PAGE),
+        )),
+        Err(e) => {
+            error!("Failed to list benchmarks: {e}");
+            Err(ServiceError::Internal)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repository::test::TestRepository;
+    use chrono::NaiveDateTime;
+    use pushkind_common::domain::benchmark::Benchmark;
+    use serde_json::Value;
+
+    fn sample_user() -> AuthenticatedUser {
+        AuthenticatedUser {
+            sub: "1".into(),
+            email: "test@example.com".into(),
+            hub_id: 1,
+            name: "Test".into(),
+            roles: vec!["parser".into()],
+            exp: 0,
+        }
+    }
+
+    fn sample_benchmark() -> Benchmark {
+        Benchmark {
+            id: 1,
+            hub_id: 1,
+            name: "benchmark".into(),
+            sku: "SKU1".into(),
+            category: "cat".into(),
+            units: "pcs".into(),
+            price: 1.0,
+            amount: 1.0,
+            description: "desc".into(),
+            created_at: NaiveDateTime::from_timestamp(0, 0),
+            updated_at: NaiveDateTime::from_timestamp(0, 0),
+            embedding: None,
+            processing: false,
+        }
+    }
+
+    #[test]
+    fn returns_benchmarks_for_authorized_user() {
+        let repo = TestRepository::new(vec![], vec![], vec![sample_benchmark()]);
+        let user = sample_user();
+
+        let paginated = show_benchmarks(&repo, &user, 1).unwrap();
+
+        let value: Value = serde_json::to_value(&paginated).unwrap();
+        assert_eq!(value["page"], 1);
+        assert_eq!(value["items"].as_array().unwrap().len(), 1);
+    }
+}

--- a/src/services/main.rs
+++ b/src/services/main.rs
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     fn returns_crawlers_for_authorized_user() {
-        let repo = TestRepository::new(vec![sample_crawler()], vec![]);
+        let repo = TestRepository::new(vec![sample_crawler()], vec![], vec![]);
         let user = sample_user();
 
         let result = show_index(&repo, &user).unwrap();

--- a/src/services/products.rs
+++ b/src/services/products.rs
@@ -105,7 +105,7 @@ mod tests {
 
     #[test]
     fn returns_products_for_authorized_user() {
-        let repo = TestRepository::new(vec![sample_crawler()], vec![sample_product()]);
+        let repo = TestRepository::new(vec![sample_crawler()], vec![sample_product()], vec![]);
         let user = sample_user();
 
         let (crawler, paginated) = show_products(&repo, &user, 1, 1).unwrap();


### PR DESCRIPTION
## Summary
- Move benchmark listing logic into `services::benchmarks::show_benchmarks`
- Make `/benchmarks` route a thin wrapper over service
- Extend `TestRepository` and add unit test for `show_benchmarks`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689cb2856134832aa4c64444ce39bebc