### PR TITLE
refactor: move benchmark page logic to service

### DIFF
--- a/src/services/benchmarks.rs
+++ b/src/services/benchmarks.rs
@@ -1,9 +1,14 @@
+use std::collections::HashMap;
+
 use log::error;
-use pushkind_common::domain::benchmark::Benchmark;
+use pushkind_common::domain::{benchmark::Benchmark, crawler::Crawler, product::Product};
 use pushkind_common::models::auth::AuthenticatedUser;
+use pushkind_common::pagination::{DEFAULT_ITEMS_PER_PAGE, Paginated};
 use pushkind_common::routes::ensure_role;
 
-use crate::repository::{BenchmarkListQuery, BenchmarkReader};
+use crate::repository::{
+    BenchmarkListQuery, BenchmarkReader, CrawlerReader, ProductListQuery, ProductReader,
+};
 
 use super::errors::{ServiceError, ServiceResult};
 
@@ -29,12 +34,77 @@ where
     }
 }
 
+/// Core business logic for rendering a single benchmark page.
+///
+/// Ensures the user has the `parser` role, verifies that the benchmark belongs
+/// to the user's hub and gathers crawlers with their products and similarity
+/// distances. Repository errors are mapped to [`ServiceError`] variants so the
+/// HTTP route remains a thin wrapper.
+pub fn show_benchmark<R>(
+    repo: &R,
+    user: &AuthenticatedUser,
+    benchmark_id: i32,
+) -> ServiceResult<(Benchmark, Vec<(Crawler, Paginated<Product>)>, HashMap<i32, f32>)>
+where
+    R: BenchmarkReader + CrawlerReader + ProductReader,
+{
+    if ensure_role(user, "parser", None).is_err() {
+        return Err(ServiceError::Unauthorized);
+    }
+
+    let benchmark = match repo.get_benchmark_by_id(benchmark_id) {
+        Ok(Some(benchmark)) if benchmark.hub_id == user.hub_id => benchmark,
+        Ok(_) => return Err(ServiceError::NotFound),
+        Err(e) => {
+            error!("Failed to get benchmark: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    let crawlers = match repo.list_crawlers(user.hub_id) {
+        Ok(crawlers) => crawlers,
+        Err(e) => {
+            error!("Failed to list crawlers: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    let mut products: Vec<(Crawler, Paginated<Product>)> = vec![];
+    for crawler in crawlers {
+        let crawler_products = match repo.list_products(
+            ProductListQuery::default()
+                .benchmark(benchmark_id)
+                .crawler(crawler.id)
+                .paginate(1, DEFAULT_ITEMS_PER_PAGE),
+        ) {
+            Ok((total, items)) => {
+                Paginated::new(items, 1, total.div_ceil(DEFAULT_ITEMS_PER_PAGE))
+            }
+            Err(e) => {
+                error!("Failed to list products: {e}");
+                return Err(ServiceError::Internal);
+            }
+        };
+        products.push((crawler, crawler_products));
+    }
+
+    let distances = match repo.list_distances(benchmark_id) {
+        Ok(distances) => distances,
+        Err(e) => {
+            error!("Failed to list distances: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    Ok((benchmark, products, distances))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::repository::test::TestRepository;
     use chrono::NaiveDateTime;
-    use pushkind_common::domain::benchmark::Benchmark;
+    use serde_json::Value;
 
     fn sample_user() -> AuthenticatedUser {
         AuthenticatedUser {
@@ -44,6 +114,37 @@ mod tests {
             name: "Test".into(),
             roles: vec!["parser".into()],
             exp: 0,
+        }
+    }
+
+    fn sample_crawler() -> Crawler {
+        Crawler {
+            id: 1,
+            hub_id: 1,
+            name: "crawler".into(),
+            url: "http://example.com".into(),
+            selector: "body".into(),
+            processing: false,
+            updated_at: NaiveDateTime::from_timestamp(0, 0),
+            num_products: 0,
+        }
+    }
+
+    fn sample_product() -> Product {
+        Product {
+            id: 1,
+            crawler_id: 1,
+            name: "product".into(),
+            sku: "SKU1".into(),
+            category: Some("cat".into()),
+            units: Some("pcs".into()),
+            price: 1.0,
+            amount: None,
+            description: None,
+            url: "http://example.com".into(),
+            created_at: NaiveDateTime::from_timestamp(0, 0),
+            updated_at: NaiveDateTime::from_timestamp(0, 0),
+            embedding: None,
         }
     }
 
@@ -73,5 +174,27 @@ mod tests {
 
         let benchmarks = show_benchmarks(&repo, &user).unwrap();
         assert_eq!(benchmarks.len(), 1);
+    }
+
+    #[test]
+    fn returns_benchmark_details_for_authorized_user() {
+        let repo = TestRepository::new(
+            vec![sample_crawler()],
+            vec![sample_product()],
+            vec![sample_benchmark()],
+        );
+        let user = sample_user();
+
+        let (benchmark, crawler_products, distances) =
+            show_benchmark(&repo, &user, 1).unwrap();
+
+        assert_eq!(benchmark.id, 1);
+        assert_eq!(crawler_products.len(), 1);
+        let (crawler, paginated) = &crawler_products[0];
+        assert_eq!(crawler.id, 1);
+        let value: Value = serde_json::to_value(paginated).unwrap();
+        assert_eq!(value["page"], 1);
+        assert_eq!(value["items"].as_array().unwrap().len(), 1);
+        assert!(distances.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- move benchmark page data loading into service layer
- slim the benchmark route to a thin wrapper
- add unit tests for benchmark service

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a1c3654d0c832a9aa4aeae8fe7b765