### PR TITLE
Refactor benchmark routes into services

### DIFF
--- a/src/routes/benchmarks.rs
+++ b/src/routes/benchmarks.rs
@@ -1,26 +1,27 @@
 use actix_multipart::form::MultipartForm;
 use actix_web::http::header;
-use actix_web::{HttpResponse, Responder, get, post, web};
+use actix_web::{get, post, web, HttpResponse, Responder};
 use actix_web_flash_messages::{FlashMessage, IncomingFlashMessages};
-use pushkind_common::domain::benchmark::NewBenchmark;
 use pushkind_common::models::auth::AuthenticatedUser;
 use pushkind_common::models::config::CommonServerConfig;
-use pushkind_common::models::zmq::dantes::CrawlerSelector;
-use pushkind_common::models::zmq::dantes::ZMQMessage;
-use pushkind_common::routes::{base_context, render_template};
-use pushkind_common::routes::{ensure_role, redirect};
+use pushkind_common::routes::{base_context, redirect, render_template};
 use pushkind_common::zmq::send_zmq_message;
 use tera::Tera;
-use validator::Validate;
 
 use crate::forms::benchmarks::{
     AddBenchmarkForm, AssociateForm, UnassociateForm, UploadBenchmarksForm,
 };
 use crate::models::config::ServerConfig;
-use crate::repository::{BenchmarkReader, BenchmarkWriter, CrawlerReader, ProductReader};
-use crate::repository::{DieselRepository, ProductListQuery};
+use crate::repository::DieselRepository;
 use crate::services::benchmarks::{
-    show_benchmark as show_benchmark_service, show_benchmarks as show_benchmarks_service,
+    add_benchmark as add_benchmark_service,
+    create_benchmark_product as create_benchmark_product_service,
+    delete_benchmark_product as delete_benchmark_product_service,
+    match_benchmark as match_benchmark_service,
+    show_benchmark as show_benchmark_service,
+    show_benchmarks as show_benchmarks_service,
+    update_benchmark_prices as update_benchmark_prices_service,
+    upload_benchmarks as upload_benchmarks_service,
 };
 use crate::services::errors::ServiceError;
 
@@ -92,27 +93,22 @@ pub async fn add_benchmark(
     repo: web::Data<DieselRepository>,
     web::Form(form): web::Form<AddBenchmarkForm>,
 ) -> impl Responder {
-    if let Err(response) = ensure_role(&user, "parser", Some("/na")) {
-        return response;
-    };
-
-    if let Err(e) = form.validate() {
-        log::error!("Failed to validate form: {e}");
-        FlashMessage::error("Ошибка валидации формы").send();
-        return redirect("/benchmarks");
-    }
-
-    let new_benchmark: NewBenchmark = form.into_new_benchmark(user.hub_id);
-
-    match repo.create_benchmark(&[new_benchmark]) {
-        Ok(_) => {
-            FlashMessage::success("Бенчмарк добавлен.".to_string()).send();
+    match add_benchmark_service(repo.get_ref(), &user, form) {
+        Ok(true) => FlashMessage::success("Бенчмарк добавлен.".to_string()).send(),
+        Ok(false) => FlashMessage::error("Ошибка при добавлении бенчмарка").send(),
+        Err(ServiceError::Unauthorized) => {
+            return HttpResponse::Found()
+                .append_header((header::LOCATION, "/na"))
+                .finish()
         }
-        Err(err) => {
-            log::error!("Failed to add a benchmark: {err}");
-            FlashMessage::error("Ошибка при добавлении бенчмарка").send();
+        Err(ServiceError::NotFound) => {
+            FlashMessage::error("Бенчмарк не существует").send();
+        }
+        Err(ServiceError::Internal) => {
+            return HttpResponse::InternalServerError().finish();
         }
     }
+
     redirect("/benchmarks")
 }
 
@@ -123,32 +119,24 @@ pub async fn match_benchmark(
     repo: web::Data<DieselRepository>,
     server_config: web::Data<ServerConfig>,
 ) -> impl Responder {
-    if let Err(response) = ensure_role(&user, "parser", Some("/na")) {
-        return response;
-    };
-
-    let benchmark_id = benchmark_id.into_inner();
-
-    let benchmark = match repo.get_benchmark_by_id(benchmark_id) {
-        Ok(Some(benchmark)) if benchmark.hub_id == user.hub_id => benchmark,
-        Err(e) => {
-            log::error!("Failed to get benchmark: {e}");
-            return redirect("/benchmarks");
+    match match_benchmark_service(
+        repo.get_ref(),
+        &user,
+        benchmark_id.into_inner(),
+        |msg| send_zmq_message(msg, &server_config.zmq_address).map_err(|_| ()),
+    ) {
+        Ok(true) => FlashMessage::success("Обработка запущена").send(),
+        Ok(false) => FlashMessage::error("Не удалось начать обработку.").send(),
+        Err(ServiceError::Unauthorized) => {
+            return HttpResponse::Found()
+                .append_header((header::LOCATION, "/na"))
+                .finish()
         }
-        _ => {
+        Err(ServiceError::NotFound) => {
             FlashMessage::error("Бенчмарк не существует").send();
-            return redirect("/benchmarks");
         }
-    };
-
-    let message = ZMQMessage::Benchmark(benchmark.id);
-    match send_zmq_message(&message, &server_config.zmq_address) {
-        Ok(_) => {
-            FlashMessage::success("Обработка запущена").send();
-        }
-        Err(e) => {
-            log::error!("Failed to send ZMQ message: {e}");
-            FlashMessage::error("Не удалось начать обработку.").send();
+        Err(ServiceError::Internal) => {
+            return HttpResponse::InternalServerError().finish();
         }
     }
 
@@ -161,26 +149,19 @@ pub async fn upload_benchmarks(
     repo: web::Data<DieselRepository>,
     MultipartForm(mut form): MultipartForm<UploadBenchmarksForm>,
 ) -> impl Responder {
-    if let Err(response) = ensure_role(&user, "parser", Some("/na")) {
-        return response;
-    };
-
-    let benchmarks = match form.parse(user.hub_id) {
-        Ok(benchmarks) => benchmarks,
-        Err(err) => {
-            log::error!("Failed to parse benchmarks: {err}");
-            FlashMessage::error("Ошибка при парсинге бенчмарков").send();
-            return redirect("/benchmarks");
+    match upload_benchmarks_service(repo.get_ref(), &user, &mut form) {
+        Ok(true) => FlashMessage::success("Бенчмарки добавлены.".to_string()).send(),
+        Ok(false) => FlashMessage::error("Ошибка при добавлении бенчмарков").send(),
+        Err(ServiceError::Unauthorized) => {
+            return HttpResponse::Found()
+                .append_header((header::LOCATION, "/na"))
+                .finish()
         }
-    };
-
-    match repo.create_benchmark(&benchmarks) {
-        Ok(_) => {
-            FlashMessage::success("Бенчмарки добавлены.".to_string()).send();
+        Err(ServiceError::Internal) => {
+            return HttpResponse::InternalServerError().finish();
         }
-        Err(err) => {
-            log::error!("Failed to add benchmarks: {err}");
-            FlashMessage::error("Ошибка при добавлении бенчмарков").send();
+        Err(ServiceError::NotFound) => {
+            FlashMessage::error("Бенчмарк не существует").send();
         }
     }
 
@@ -194,66 +175,39 @@ pub async fn update_benchmark_prices(
     repo: web::Data<DieselRepository>,
     server_config: web::Data<ServerConfig>,
 ) -> impl Responder {
-    if let Err(response) = ensure_role(&user, "parser", Some("/na")) {
-        return response;
-    }
-
-    let benchmark_id = benchmark_id.into_inner();
-
-    let benchmark = match repo.get_benchmark_by_id(benchmark_id) {
-        Ok(Some(benchmark)) if benchmark.hub_id == user.hub_id => benchmark,
-        Err(e) => {
-            log::error!("Failed to get benchmark: {e}");
-            return redirect("/benchmarks");
-        }
-        _ => {
-            FlashMessage::error("Бенчмарк не существует").send();
-            return redirect("/benchmarks");
-        }
-    };
-
-    let crawlers = match repo.list_crawlers(user.hub_id) {
-        Ok(crawlers) => crawlers,
-        Err(e) => {
-            log::error!("Failed to list crawlers: {e}");
-            return HttpResponse::InternalServerError().finish();
-        }
-    };
-
-    for crawler in crawlers {
-        let crawler_products = match repo.list_products(
-            ProductListQuery::default()
-                .benchmark(benchmark.id)
-                .crawler(crawler.id),
-        ) {
-            Ok((_total, products)) => products,
-            Err(e) => {
-                log::error!("Failed to list products: {e}");
-                return HttpResponse::InternalServerError().finish();
-            }
-        };
-
-        if crawler_products.is_empty() {
-            continue;
-        }
-
-        let message = ZMQMessage::Crawler(CrawlerSelector::SelectorProducts((
-            crawler.selector.clone(),
-            crawler_products.into_iter().map(|p| p.url).collect(),
-        )));
-        match send_zmq_message(&message, &server_config.zmq_address) {
-            Ok(_) => {
-                FlashMessage::success(format!("Обработка запущена для {}", crawler.selector))
+    match update_benchmark_prices_service(
+        repo.get_ref(),
+        &user,
+        benchmark_id.into_inner(),
+        |msg| send_zmq_message(msg, &server_config.zmq_address).map_err(|_| ()),
+    ) {
+        Ok(results) => {
+            for (selector, sent) in results {
+                if sent {
+                    FlashMessage::success(format!(
+                        "Обработка запущена для {}",
+                        selector
+                    ))
                     .send();
+                } else {
+                    FlashMessage::error(format!(
+                        "Не удалось начать обработку для {}",
+                        selector
+                    ))
+                    .send();
+                }
             }
-            Err(e) => {
-                log::error!("Failed to send ZMQ message: {e}");
-                FlashMessage::error(format!(
-                    "Не удалось начать обработку для {}",
-                    crawler.selector
-                ))
-                .send();
-            }
+        }
+        Err(ServiceError::Unauthorized) => {
+            return HttpResponse::Found()
+                .append_header((header::LOCATION, "/na"))
+                .finish();
+        }
+        Err(ServiceError::NotFound) => {
+            FlashMessage::error("Бенчмарк не существует").send();
+        }
+        Err(ServiceError::Internal) => {
+            return HttpResponse::InternalServerError().finish();
         }
     }
 
@@ -266,54 +220,20 @@ pub async fn delete_benchmark_product(
     repo: web::Data<DieselRepository>,
     web::Form(form): web::Form<UnassociateForm>,
 ) -> impl Responder {
-    if let Err(response) = ensure_role(&user, "parser", Some("/na")) {
-        return response;
-    };
-
-    let benchmark_id = form.benchmark_id;
-    let product_id = form.product_id;
-
-    let benchmark = match repo.get_benchmark_by_id(benchmark_id) {
-        Ok(Some(benchmark)) if benchmark.hub_id == user.hub_id => benchmark,
-        Err(e) => {
-            log::error!("Failed to get benchmark: {e}");
+    match delete_benchmark_product_service(repo.get_ref(), &user, form) {
+        Ok(true) => FlashMessage::success("Мэтчинг удален.").send(),
+        Ok(false) => FlashMessage::error("Ошибка при удалении мэтчинга").send(),
+        Err(ServiceError::Unauthorized) => {
+            return HttpResponse::Found()
+                .append_header((header::LOCATION, "/na"))
+                .finish();
+        }
+        Err(ServiceError::NotFound) => {
+            FlashMessage::error("Бенчмарк или товар не существует").send();
+        }
+        Err(ServiceError::Internal) => {
             return HttpResponse::InternalServerError().finish();
         }
-        _ => {
-            FlashMessage::error("Бенчмарк не существует").send();
-            return redirect("/benchmarks");
-        }
-    };
-
-    let product = match repo.get_product_by_id(product_id) {
-        Ok(Some(product)) => product,
-        Ok(None) => {
-            FlashMessage::error("Товар не существует.").send();
-            return redirect("/benchmarks");
-        }
-        Err(e) => {
-            log::error!("Failed to get product: {e}");
-            return HttpResponse::InternalServerError().finish();
-        }
-    };
-
-    let _crawler = match repo.get_crawler_by_id(product.crawler_id) {
-        Ok(Some(crawler)) if crawler.hub_id == user.hub_id => crawler,
-        Err(e) => {
-            log::error!("Failed to get crawler: {e}");
-            return HttpResponse::InternalServerError().finish();
-        }
-        _ => {
-            FlashMessage::error("Парсер не существует").send();
-            return redirect("/benchmarks");
-        }
-    };
-
-    if let Err(e) = repo.remove_benchmark_association(benchmark.id, product.id) {
-        log::error!("Failed to delete association: {e}");
-        FlashMessage::error("Ошибка при удалении мэтчинга").send();
-    } else {
-        FlashMessage::success("Мэтчинг удален.").send();
     }
 
     redirect("/benchmarks")
@@ -325,54 +245,20 @@ pub async fn create_benchmark_product(
     repo: web::Data<DieselRepository>,
     web::Form(form): web::Form<AssociateForm>,
 ) -> impl Responder {
-    if let Err(response) = ensure_role(&user, "parser", Some("/na")) {
-        return response;
-    };
-
-    let benchmark_id = form.benchmark_id;
-    let product_id = form.product_id;
-
-    let benchmark = match repo.get_benchmark_by_id(benchmark_id) {
-        Ok(Some(benchmark)) if benchmark.hub_id == user.hub_id => benchmark,
-        Err(e) => {
-            log::error!("Failed to get benchmark: {e}");
+    match create_benchmark_product_service(repo.get_ref(), &user, form) {
+        Ok(true) => FlashMessage::success("Мэтчинг добавлен.").send(),
+        Ok(false) => FlashMessage::error("Ошибка при добавлении мэтчинга").send(),
+        Err(ServiceError::Unauthorized) => {
+            return HttpResponse::Found()
+                .append_header((header::LOCATION, "/na"))
+                .finish();
+        }
+        Err(ServiceError::NotFound) => {
+            FlashMessage::error("Бенчмарк или товар не существует").send();
+        }
+        Err(ServiceError::Internal) => {
             return HttpResponse::InternalServerError().finish();
         }
-        _ => {
-            FlashMessage::error("Бенчмарк не существует").send();
-            return redirect("/benchmarks");
-        }
-    };
-
-    let product = match repo.get_product_by_id(product_id) {
-        Ok(Some(product)) => product,
-        Ok(None) => {
-            FlashMessage::error("Товар не существует").send();
-            return redirect("/benchmarks");
-        }
-        Err(e) => {
-            log::error!("Failed to get product: {e}");
-            return HttpResponse::InternalServerError().finish();
-        }
-    };
-
-    let _crawler = match repo.get_crawler_by_id(product.crawler_id) {
-        Ok(Some(crawler)) if crawler.hub_id == user.hub_id => crawler,
-        Err(e) => {
-            log::error!("Failed to get crawler: {e}");
-            return HttpResponse::InternalServerError().finish();
-        }
-        _ => {
-            FlashMessage::error("Парсер не существует").send();
-            return redirect("/benchmarks");
-        }
-    };
-
-    if let Err(e) = repo.set_benchmark_association(benchmark.id, product.id, 1.0) {
-        log::error!("Failed to create benchmark association: {e}");
-        FlashMessage::error("Ошибка при добавлении мэтчинга").send();
-    } else {
-        FlashMessage::success("Мэтчинг добавлен.").send();
     }
 
     redirect("/benchmarks")

--- a/src/services/benchmarks.rs
+++ b/src/services/benchmarks.rs
@@ -6,9 +6,15 @@ use pushkind_common::models::auth::AuthenticatedUser;
 use pushkind_common::pagination::{DEFAULT_ITEMS_PER_PAGE, Paginated};
 use pushkind_common::routes::ensure_role;
 
-use crate::repository::{
-    BenchmarkListQuery, BenchmarkReader, CrawlerReader, ProductListQuery, ProductReader,
+use crate::forms::benchmarks::{
+    AddBenchmarkForm, AssociateForm, UnassociateForm, UploadBenchmarksForm,
 };
+use crate::repository::{
+    BenchmarkListQuery, BenchmarkReader, BenchmarkWriter, CrawlerReader, ProductListQuery,
+    ProductReader,
+};
+use pushkind_common::models::zmq::dantes::{CrawlerSelector, ZMQMessage};
+use validator::Validate;
 
 use super::errors::{ServiceError, ServiceResult};
 
@@ -99,12 +105,284 @@ where
     Ok((benchmark, products, distances))
 }
 
+/// Adds a new benchmark from the supplied form.
+///
+/// Validates the `parser` role and the form itself before persisting the
+/// benchmark. Returns `Ok(true)` if the benchmark was created, `Ok(false)` if
+/// validation failed or the repository returned an error.
+pub fn add_benchmark<R>(
+    repo: &R,
+    user: &AuthenticatedUser,
+    form: AddBenchmarkForm,
+) -> ServiceResult<bool>
+where
+    R: BenchmarkWriter,
+{
+    if ensure_role(user, "parser", None).is_err() {
+        return Err(ServiceError::Unauthorized);
+    }
+
+    if let Err(e) = form.validate() {
+        error!("Failed to validate form: {e}");
+        return Ok(false);
+    }
+
+    let new_benchmark = form.into_new_benchmark(user.hub_id);
+
+    match repo.create_benchmark(&[new_benchmark]) {
+        Ok(_) => Ok(true),
+        Err(e) => {
+            error!("Failed to add a benchmark: {e}");
+            Ok(false)
+        }
+    }
+}
+
+/// Parses and uploads multiple benchmarks.
+///
+/// Returns `Ok(true)` if benchmarks were created successfully, `Ok(false)` if
+/// parsing failed or the repository returned an error.
+pub fn upload_benchmarks<R>(
+    repo: &R,
+    user: &AuthenticatedUser,
+    form: &mut UploadBenchmarksForm,
+) -> ServiceResult<bool>
+where
+    R: BenchmarkWriter,
+{
+    if ensure_role(user, "parser", None).is_err() {
+        return Err(ServiceError::Unauthorized);
+    }
+
+    let benchmarks = match form.parse(user.hub_id) {
+        Ok(benchmarks) => benchmarks,
+        Err(e) => {
+            error!("Failed to parse benchmarks: {e}");
+            return Ok(false);
+        }
+    };
+
+    match repo.create_benchmark(&benchmarks) {
+        Ok(_) => Ok(true),
+        Err(e) => {
+            error!("Failed to add benchmarks: {e}");
+            Ok(false)
+        }
+    }
+}
+
+/// Sends a ZMQ message to match the specified benchmark.
+///
+/// Returns `Ok(true)` if the message was sent successfully, `Ok(false)` if
+/// sending failed.
+pub fn match_benchmark<R, F>(
+    repo: &R,
+    user: &AuthenticatedUser,
+    benchmark_id: i32,
+    send: F,
+) -> ServiceResult<bool>
+where
+    R: BenchmarkReader,
+    F: Fn(&ZMQMessage) -> Result<(), ()>,
+{
+    if ensure_role(user, "parser", None).is_err() {
+        return Err(ServiceError::Unauthorized);
+    }
+
+    let benchmark = match repo.get_benchmark_by_id(benchmark_id) {
+        Ok(Some(benchmark)) if benchmark.hub_id == user.hub_id => benchmark,
+        Ok(_) => return Err(ServiceError::NotFound),
+        Err(e) => {
+            error!("Failed to get benchmark: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    let message = ZMQMessage::Benchmark(benchmark.id);
+    match send(&message) {
+        Ok(_) => Ok(true),
+        Err(_) => {
+            error!("Failed to send ZMQ message");
+            Ok(false)
+        }
+    }
+}
+
+/// Sends ZMQ messages to update prices for all products associated with a benchmark.
+///
+/// Returns a list of crawler selectors and whether sending the message for that
+/// crawler succeeded.
+pub fn update_benchmark_prices<R, F>(
+    repo: &R,
+    user: &AuthenticatedUser,
+    benchmark_id: i32,
+    send: F,
+) -> ServiceResult<Vec<(String, bool)>>
+where
+    R: BenchmarkReader + CrawlerReader + ProductReader,
+    F: Fn(&ZMQMessage) -> Result<(), ()>,
+{
+    if ensure_role(user, "parser", None).is_err() {
+        return Err(ServiceError::Unauthorized);
+    }
+
+    let benchmark = match repo.get_benchmark_by_id(benchmark_id) {
+        Ok(Some(benchmark)) if benchmark.hub_id == user.hub_id => benchmark,
+        Ok(_) => return Err(ServiceError::NotFound),
+        Err(e) => {
+            error!("Failed to get benchmark: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    let crawlers = match repo.list_crawlers(user.hub_id) {
+        Ok(crawlers) => crawlers,
+        Err(e) => {
+            error!("Failed to list crawlers: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    let mut results = Vec::new();
+    for crawler in crawlers {
+        let products = match repo.list_products(
+            ProductListQuery::default().benchmark(benchmark.id).crawler(crawler.id),
+        ) {
+            Ok((_total, products)) => products,
+            Err(e) => {
+                error!("Failed to list products: {e}");
+                return Err(ServiceError::Internal);
+            }
+        };
+
+        if products.is_empty() {
+            continue;
+        }
+
+        let urls = products.into_iter().map(|p| p.url).collect();
+        let message =
+            ZMQMessage::Crawler(CrawlerSelector::SelectorProducts((crawler.selector.clone(), urls)));
+        let sent = send(&message).is_ok();
+        if !sent {
+            error!("Failed to send ZMQ message");
+        }
+        results.push((crawler.selector, sent));
+    }
+
+    Ok(results)
+}
+
+/// Removes an association between a benchmark and a product.
+///
+/// Returns `Ok(true)` if the association was removed, `Ok(false)` if the
+/// repository returned an error or entities were not found.
+pub fn delete_benchmark_product<R>(
+    repo: &R,
+    user: &AuthenticatedUser,
+    form: UnassociateForm,
+) -> ServiceResult<bool>
+where
+    R: BenchmarkReader + ProductReader + CrawlerReader + BenchmarkWriter,
+{
+    if ensure_role(user, "parser", None).is_err() {
+        return Err(ServiceError::Unauthorized);
+    }
+
+    let benchmark = match repo.get_benchmark_by_id(form.benchmark_id) {
+        Ok(Some(b)) if b.hub_id == user.hub_id => b,
+        Ok(_) => return Err(ServiceError::NotFound),
+        Err(e) => {
+            error!("Failed to get benchmark: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    let product = match repo.get_product_by_id(form.product_id) {
+        Ok(Some(p)) => p,
+        Ok(None) => return Err(ServiceError::NotFound),
+        Err(e) => {
+            error!("Failed to get product: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    match repo.get_crawler_by_id(product.crawler_id) {
+        Ok(Some(crawler)) if crawler.hub_id == user.hub_id => crawler,
+        Ok(_) => return Err(ServiceError::NotFound),
+        Err(e) => {
+            error!("Failed to get crawler: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    match repo.remove_benchmark_association(benchmark.id, product.id) {
+        Ok(_) => Ok(true),
+        Err(e) => {
+            error!("Failed to delete association: {e}");
+            Ok(false)
+        }
+    }
+}
+
+/// Creates an association between a benchmark and a product.
+///
+/// Returns `Ok(true)` if the association was created, `Ok(false)` if the
+/// repository returned an error or entities were not found.
+pub fn create_benchmark_product<R>(
+    repo: &R,
+    user: &AuthenticatedUser,
+    form: AssociateForm,
+) -> ServiceResult<bool>
+where
+    R: BenchmarkReader + ProductReader + CrawlerReader + BenchmarkWriter,
+{
+    if ensure_role(user, "parser", None).is_err() {
+        return Err(ServiceError::Unauthorized);
+    }
+
+    let benchmark = match repo.get_benchmark_by_id(form.benchmark_id) {
+        Ok(Some(b)) if b.hub_id == user.hub_id => b,
+        Ok(_) => return Err(ServiceError::NotFound),
+        Err(e) => {
+            error!("Failed to get benchmark: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    let product = match repo.get_product_by_id(form.product_id) {
+        Ok(Some(p)) => p,
+        Ok(None) => return Err(ServiceError::NotFound),
+        Err(e) => {
+            error!("Failed to get product: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    match repo.get_crawler_by_id(product.crawler_id) {
+        Ok(Some(crawler)) if crawler.hub_id == user.hub_id => crawler,
+        Ok(_) => return Err(ServiceError::NotFound),
+        Err(e) => {
+            error!("Failed to get crawler: {e}");
+            return Err(ServiceError::Internal);
+        }
+    };
+
+    match repo.set_benchmark_association(benchmark.id, product.id, 1.0) {
+        Ok(_) => Ok(true),
+        Err(e) => {
+            error!("Failed to create benchmark association: {e}");
+            Ok(false)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::repository::test::TestRepository;
     use chrono::NaiveDateTime;
     use serde_json::Value;
+    use pushkind_common::models::zmq::dantes::{CrawlerSelector, ZMQMessage};
 
     fn sample_user() -> AuthenticatedUser {
         AuthenticatedUser {
@@ -196,5 +474,50 @@ mod tests {
         assert_eq!(value["page"], 1);
         assert_eq!(value["items"].as_array().unwrap().len(), 1);
         assert!(distances.is_empty());
+    }
+
+    #[test]
+    fn match_benchmark_sends_message() {
+        let repo = TestRepository::new(vec![], vec![], vec![sample_benchmark()]);
+        let user = sample_user();
+
+        let result = match_benchmark(&repo, &user, 1, |msg| {
+            match msg {
+                ZMQMessage::Benchmark(id) => {
+                    assert_eq!(*id, 1);
+                    Ok(())
+                }
+                _ => Err(()),
+            }
+        })
+        .unwrap();
+
+        assert!(result);
+    }
+
+    #[test]
+    fn update_benchmark_prices_sends_messages() {
+        let repo = TestRepository::new(
+            vec![sample_crawler()],
+            vec![sample_product()],
+            vec![sample_benchmark()],
+        );
+        let user = sample_user();
+
+        let result = update_benchmark_prices(&repo, &user, 1, |msg| {
+            match msg {
+                ZMQMessage::Crawler(CrawlerSelector::SelectorProducts((sel, urls))) => {
+                    assert_eq!(sel, "body");
+                    assert_eq!(urls.len(), 1);
+                    assert_eq!(urls[0], "http://example.com");
+                    Ok(())
+                }
+                _ => Err(()),
+            }
+        })
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].1);
     }
 }


### PR DESCRIPTION
## Summary
- Move benchmark create/update/match logic into service layer
- Keep Actix routes as thin wrappers around services
- Cover benchmark message handling with unit tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a1e4547d38832a9963d40a0b34ff3b